### PR TITLE
Add simple Sinatra web tracker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'sinatra'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,34 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    base64 (0.3.0)
+    logger (1.7.0)
+    mustermann (3.0.3)
+      ruby2_keywords (~> 0.0.1)
+    rack (3.1.16)
+    rack-protection (4.1.1)
+      base64 (>= 0.1.0)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
+    rack-session (2.1.1)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0)
+    ruby2_keywords (0.0.5)
+    sinatra (4.1.1)
+      logger (>= 1.6.0)
+      mustermann (~> 3.0)
+      rack (>= 3.0.0, < 4)
+      rack-protection (= 4.1.1)
+      rack-session (>= 2.0.0, < 3)
+      tilt (~> 2.0)
+    tilt (2.6.1)
+
+PLATFORMS
+  ruby
+  x86_64-linux
+
+DEPENDENCIES
+  sinatra
+
+BUNDLED WITH
+   2.6.7

--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
 # Warcry-Tracker
-This is a tool you can use when playing Warcry to track things like activations, HP, treasures, etc.
+
+A small Sinatra web application to help track fighters during a Warcry game. It keeps track of hit points, activation status each round and any items or treasures a fighter carries.
+
+## Setup
+
+Install dependencies with Bundler:
+
+```bash
+bundle install
+```
+
+## Running
+
+Start the web server:
+
+```bash
+ruby app.rb
+```
+
+Then open [http://localhost:4567](http://localhost:4567) in your web browser.
+
+## Features
+
+- Add fighters with a starting amount of HP
+- Damage or heal fighters
+- Mark fighters as activated or deactivate them
+- Start a new round to reset activations
+- Give or take items from fighters
+
+The previous command line script `warcry_tracker.rb` is still included if you prefer running in the terminal.

--- a/app.rb
+++ b/app.rb
@@ -1,0 +1,126 @@
+require 'sinatra'
+
+class Fighter
+  attr_accessor :name, :hp, :max_hp, :activated, :items
+
+  def initialize(name, hp)
+    @name = name
+    @hp = hp
+    @max_hp = hp
+    @activated = false
+    @items = []
+  end
+
+  def damage(amount)
+    @hp -= amount
+    @hp = 0 if @hp < 0
+  end
+
+  def heal(amount)
+    @hp += amount
+    @hp = @max_hp if @hp > @max_hp
+  end
+end
+
+class Tracker
+  attr_reader :fighters
+
+  def initialize
+    @fighters = []
+  end
+
+  def add_fighter(name, hp)
+    @fighters << Fighter.new(name, hp)
+  end
+
+  def find_fighter(name)
+    @fighters.find { |f| f.name.downcase == name.downcase }
+  end
+
+  def damage(name, amount)
+    f = find_fighter(name)
+    return unless f
+    f.damage(amount)
+  end
+
+  def heal(name, amount)
+    f = find_fighter(name)
+    return unless f
+    f.heal(amount)
+  end
+
+  def activate(name)
+    f = find_fighter(name)
+    return unless f
+    f.activated = true
+  end
+
+  def deactivate(name)
+    f = find_fighter(name)
+    return unless f
+    f.activated = false
+  end
+
+  def new_round
+    @fighters.each { |f| f.activated = false }
+  end
+
+  def give_item(name, item)
+    f = find_fighter(name)
+    return unless f
+    f.items << item
+  end
+
+  def take_item(name, item)
+    f = find_fighter(name)
+    return unless f
+    f.items.delete(item)
+  end
+end
+
+tracker = Tracker.new
+
+get '/' do
+  @fighters = tracker.fighters
+  erb :index
+end
+
+post '/fighters' do
+  tracker.add_fighter(params[:name], params[:hp].to_i)
+  redirect '/'
+end
+
+post '/fighters/:name/damage' do
+  tracker.damage(params[:name], params[:amount].to_i)
+  redirect '/'
+end
+
+post '/fighters/:name/heal' do
+  tracker.heal(params[:name], params[:amount].to_i)
+  redirect '/'
+end
+
+post '/fighters/:name/activate' do
+  tracker.activate(params[:name])
+  redirect '/'
+end
+
+post '/fighters/:name/deactivate' do
+  tracker.deactivate(params[:name])
+  redirect '/'
+end
+
+post '/newround' do
+  tracker.new_round
+  redirect '/'
+end
+
+post '/fighters/:name/give' do
+  tracker.give_item(params[:name], params[:item])
+  redirect '/'
+end
+
+post '/fighters/:name/take' do
+  tracker.take_item(params[:name], params[:item])
+  redirect '/'
+end

--- a/views/index.erb
+++ b/views/index.erb
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Warcry Tracker</title>
+  <style>
+    table { border-collapse: collapse; }
+    th, td { border: 1px solid #ccc; padding: 4px; }
+    form { display: inline; margin: 0; }
+  </style>
+</head>
+<body>
+  <h1>Warcry Tracker</h1>
+
+  <form action="/newround" method="post">
+    <button type="submit">Start New Round</button>
+  </form>
+
+  <h2>Add Fighter</h2>
+  <form action="/fighters" method="post">
+    Name: <input type="text" name="name" required>
+    HP: <input type="number" name="hp" value="10" min="1" required>
+    <button type="submit">Add</button>
+  </form>
+
+  <h2>Fighters</h2>
+  <table>
+    <tr>
+      <th>Name</th>
+      <th>HP</th>
+      <th>Activated</th>
+      <th>Items</th>
+      <th>Actions</th>
+    </tr>
+    <% @fighters.each do |f| %>
+    <tr>
+      <td><%= f.name %></td>
+      <td><%= f.hp %>/<%= f.max_hp %></td>
+      <td><%= f.activated ? 'Yes' : 'No' %></td>
+      <td><%= f.items.join(', ') %></td>
+      <td>
+        <form action="/fighters/<%= f.name %>/damage" method="post">
+          <input type="number" name="amount" min="1" value="1" style="width:60px">
+          <button type="submit">Damage</button>
+        </form>
+        <form action="/fighters/<%= f.name %>/heal" method="post">
+          <input type="number" name="amount" min="1" value="1" style="width:60px">
+          <button type="submit">Heal</button>
+        </form>
+        <% if f.activated %>
+          <form action="/fighters/<%= f.name %>/deactivate" method="post">
+            <button type="submit">Deactivate</button>
+          </form>
+        <% else %>
+          <form action="/fighters/<%= f.name %>/activate" method="post">
+            <button type="submit">Activate</button>
+          </form>
+        <% end %>
+        <form action="/fighters/<%= f.name %>/give" method="post">
+          <input type="text" name="item" placeholder="Item" style="width:70px">
+          <button type="submit">Give</button>
+        </form>
+        <form action="/fighters/<%= f.name %>/take" method="post">
+          <input type="text" name="item" placeholder="Item" style="width:70px">
+          <button type="submit">Take</button>
+        </form>
+      </td>
+    </tr>
+    <% end %>
+  </table>
+</body>
+</html>

--- a/warcry_tracker.rb
+++ b/warcry_tracker.rb
@@ -1,0 +1,132 @@
+class Fighter
+  attr_accessor :name, :hp, :max_hp, :activated, :items
+
+  def initialize(name, hp)
+    @name = name
+    @hp = hp
+    @max_hp = hp
+    @activated = false
+    @items = []
+  end
+
+  def damage(amount)
+    @hp -= amount
+    @hp = 0 if @hp < 0
+  end
+
+  def heal(amount)
+    @hp += amount
+    @hp = @max_hp if @hp > @max_hp
+  end
+
+  def status
+    status = "#{@name}: #{@hp}/#{@max_hp} HP"
+    status += " [ACTIVATED]" if @activated
+    status += " Items: #{@items.join(', ')}" unless @items.empty?
+    status
+  end
+end
+
+class Tracker
+  def initialize
+    @fighters = []
+  end
+
+  def add_fighter(name, hp)
+    @fighters << Fighter.new(name, hp)
+  end
+
+  def find_fighter(name)
+    @fighters.find { |f| f.name.downcase == name.downcase }
+  end
+
+  def list
+    puts "Fighters:"
+    @fighters.each { |f| puts f.status }
+  end
+
+  def damage(name, amount)
+    f = find_fighter(name)
+    return puts "Fighter not found" unless f
+    f.damage(amount)
+  end
+
+  def heal(name, amount)
+    f = find_fighter(name)
+    return puts "Fighter not found" unless f
+    f.heal(amount)
+  end
+
+  def activate(name)
+    f = find_fighter(name)
+    return puts "Fighter not found" unless f
+    f.activated = true
+  end
+
+  def deactivate(name)
+    f = find_fighter(name)
+    return puts "Fighter not found" unless f
+    f.activated = false
+  end
+
+  def new_round
+    @fighters.each { |f| f.activated = false }
+    puts "New battle round started. All fighters are ready."
+  end
+
+  def give_item(name, item)
+    f = find_fighter(name)
+    return puts "Fighter not found" unless f
+    f.items << item
+  end
+
+  def take_item(name, item)
+    f = find_fighter(name)
+    return puts "Fighter not found" unless f
+    f.items.delete(item)
+  end
+end
+
+tracker = Tracker.new
+puts "Warcry Tracker"
+loop do
+  print "> "
+  input = gets
+  break if input.nil?
+  cmd, *args = input.strip.split(/\s+/)
+  case cmd
+  when 'add'
+    name = args[0]
+    hp = args[1].to_i
+    tracker.add_fighter(name, hp)
+  when 'list'
+    tracker.list
+  when 'damage'
+    name = args[0]
+    amount = args[1].to_i
+    tracker.damage(name, amount)
+  when 'heal'
+    name = args[0]
+    amount = args[1].to_i
+    tracker.heal(name, amount)
+  when 'activate'
+    tracker.activate(args[0])
+  when 'deactivate'
+    tracker.deactivate(args[0])
+  when 'newround'
+    tracker.new_round
+  when 'give'
+    name = args[0]
+    item = args[1]
+    tracker.give_item(name, item)
+  when 'take'
+    name = args[0]
+    item = args[1]
+    tracker.take_item(name, item)
+  when 'quit', 'exit'
+    break
+  else
+    puts "Commands: add NAME HP, list, damage NAME AMOUNT, heal NAME AMOUNT, " \
+         "activate NAME, deactivate NAME, newround, give NAME ITEM, take NAME ITEM, quit"
+  end
+end


### PR DESCRIPTION
## Summary
- turn the tracker into a tiny Sinatra web app
- add HTML view for interacting with fighters
- document how to run the web server
- keep the old CLI script for reference

## Testing
- `bundle install`
- `ruby -c app.rb`
- `ruby -c warcry_tracker.rb`
- `ruby app.rb -o 127.0.0.1 -p 4567 >/tmp/app.log 2>&1 &`; `curl -s http://localhost:4567 | head`

------
https://chatgpt.com/codex/tasks/task_e_688434c723908322817216faca49ae57